### PR TITLE
update ADC functions

### DIFF
--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -3,13 +3,13 @@
 #' Function to calculate the Apparent Digestibility Coefficient (ADC) of the dry 
 #' matter fraction of a compound diet.
 #' 
-#' @param es_diet a numeric value, resembling the inclusion rate of external
+#' @param std_diet a numeric value, resembling the inclusion rate of
 #' standard in the experimental diet given to the livestock.
-#' @param es_feces a numeric value, resembling the inclusion rate of external
+#' @param std_feces a numeric value, resembling the inclusion rate of
 #' standard in the feces recovered during the digestibility trial.
 #' 
-#' @return returns a single numeric value which is the relative ADC for the
-#' dry matter content of the diet. If the value is not within the interval [0,1], 
+#' @return returns a single numeric value in the interval [0, 1], which is the relative ADC for the
+#' dry matter content of the diet. If the value is not within the interval, 
 #' an additional warning is returned.
 #' 
 #' @author Anıl Axel Tellbüscher
@@ -18,26 +18,26 @@
 #' Aquaculture. Aquaculture, 252, p.103–105.
 #' 
 #' @export
-adc_dm <- function(es_diet, es_feces) {
+adc_dm <- function(std_diet, std_feces) {
   
   # Checks----
   ## Ensure inputs are numeric
-  stopifnot(is.numeric(es_diet), is.numeric(es_feces))
+  stopifnot(is.numeric(std_diet), is.numeric(std_feces))
   
   
   ## Ensure inputs have the same length
-  if (length(es_diet) != length(es_feces)) {
-    stop("Error: inputs must be of the same length.")
+  if (length(std_diet) != length(std_feces)) {
+    stop("All input vectors must have the same length.")
   }
   
   
   ## Check whether inputs are > 0
-  if (any(es_diet < 0 | es_feces < 0)) {
+  if (any(std_diet < 0 | std_feces < 0)) {
     warning("Some input values are negative. The result may not be meaningful.")
   }
   
   
   # Calculations----
-  adc_dm <- 1 - (es_diet / es_feces)
+  adc_dm <- 1 - (std_diet / std_feces)
   return(adc_dm)
 }

--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -19,10 +19,25 @@
 #' 
 #' @export
 adc_dm <- function(es_diet, es_feces) {
-
-  # calculate ADC
+  
+  # Checks----
+  ## Ensure inputs are numeric
+  stopifnot(is.numeric(es_diet), is.numeric(es_feces))
+  
+  
+  ## Ensure inputs have the same length
+  if (length(es_diet) != length(es_feces)) {
+    stop("Error: inputs must be of the same length.")
+  }
+  
+  
+  ## Check whether inputs are > 0
+  if (any(es_diet < 0 | es_feces < 0)) {
+    warning("Some input values are negative. The result may not be meaningful.")
+  }
+  
+  
+  # Calculations----
   adc_dm <- 1 - (es_diet / es_feces)
-
-  # return result
   return(adc_dm)
 }

--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -48,5 +48,10 @@ adc_dm <- function(dm_diet, std_diet, std_feces) {
   
   # Calculations----
   adc_dm <- 1 - (dm_diet*std_diet / std_feces)
+  
+  if(adc_dm > 1) {
+    warning("ADC > 1")
+  }
+  
   return(adc_dm)
 }

--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -15,8 +15,9 @@
 #' 
 #' @author Anıl Axel Tellbüscher
 #' 
-#' @references Bureau, D. P., & Hua, K. (2006): Letter to the Editor of
-#' Aquaculture. Aquaculture, 252, p.103–105.
+#' @references Bureau, D. P., Harris, A. M. & Cho, C. Y. (1999): Apparent digestibility of rendered 
+#' animal protein ingredients for rainbow troue (Oncorhynchus mykiss). 
+#' Aquaculture, 180, p.345-358.
 #' 
 #' @examples
 #' # 900 g/kg (90%) dry matter content of feed

--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -3,6 +3,7 @@
 #' Function to calculate the Apparent Digestibility Coefficient (ADC) of the dry 
 #' matter fraction of a compound diet.
 #' 
+#' @param dm_diet a numeric value, being the dry matter content of the diet
 #' @param std_diet a numeric value, resembling the inclusion rate of
 #' standard in the experimental diet given to the livestock.
 #' @param std_feces a numeric value, resembling the inclusion rate of
@@ -17,27 +18,35 @@
 #' @references Bureau, D. P., & Hua, K. (2006): Letter to the Editor of
 #' Aquaculture. Aquaculture, 252, p.103–105.
 #' 
+#' @examples
+#' # 900 g/kg (90%) dry matter content of feed
+#' # 10 g/kg (1%) digestibility standard in feed
+#' # 45 g/kg (4.5%) digestibility standard in feces
+#' adc_dm(dm_diet = 0.95, std_diet = 0.01, std_feces = 0.045)
+#' 
+#' 
 #' @export
-adc_dm <- function(std_diet, std_feces) {
+adc_dm <- function(dm_diet, std_diet, std_feces) {
   
   # Checks----
   ## Ensure inputs are numeric
-  stopifnot(is.numeric(std_diet), is.numeric(std_feces))
+  stopifnot(is.numeric(std_diet), is.numeric(std_feces), is.numeric(dm_diet))
   
   
-  ## Ensure inputs have the same length
-  if (length(std_diet) != length(std_feces)) {
+  ## Ensure all inputs have the same length
+  input_lengths <- c(length(dm_diet), length(std_diet), ;ength(std_feces))
+  if (length(unique(input_lengths)) != 1) {
     stop("All input vectors must have the same length.")
   }
   
   
   ## Check whether inputs are > 0
-  if (any(std_diet < 0 | std_feces < 0)) {
+  if (any(std_diet < 0 | std_feces < 0 | dm_diet < 0)) {
     warning("Some input values are negative. The result may not be meaningful.")
   }
   
   
   # Calculations----
-  adc_dm <- 1 - (std_diet / std_feces)
+  adc_dm <- 1 - (dm_diet*std_diet / std_feces)
   return(adc_dm)
 }

--- a/R/adc_dm.R
+++ b/R/adc_dm.R
@@ -34,7 +34,7 @@ adc_dm <- function(dm_diet, std_diet, std_feces) {
   
   
   ## Ensure all inputs have the same length
-  input_lengths <- c(length(dm_diet), length(std_diet), ;ength(std_feces))
+  input_lengths <- c(length(dm_diet), length(std_diet), length(std_feces))
   if (length(unique(input_lengths)) != 1) {
     stop("All input vectors must have the same length.")
   }

--- a/R/adc_ingr.R
+++ b/R/adc_ingr.R
@@ -1,7 +1,8 @@
 #' ADC of a feed ingredient (ADCingr)
 #' 
 #' Function to calculate the Apparent Digestibility Coefficient of a nutrient 
-#' contained in a feed ingredient of a compound diet.
+#' contained in a feed ingredient of a compound diet. The calculation of the 
+#' ADCingr is based on the equation proposed by Bureau and Hua (2006).
 #' 
 #' @param adc_test a numeric value in the interval [0,1] that represents the
 #' Apparent Digestibility Coefficient (ADC) of the diet that contains the
@@ -20,12 +21,9 @@
 #' Digestibility Coefficient (ADC) of the nutrient in an ingredient will be
 #' calculated.
 #' 
-#' @return returns a single numeric value which is the relative ADC for the
-#' diet. If the value is not within the interval [0,1], an additional warning
+#' @return returns a single numeric value in the interval [0, 1], which is the relative ADC for the
+#' diet. If the value is not within the interval, an additional warning
 #' is returned.
-#' 
-#' @note The calculation of the ADCingr is based on the equation proposed by Bureau
-#' and Hua (2006).
 #' 
 #' @author Anıl Axel Tellbüscher
 #' 

--- a/R/adc_ingr.R
+++ b/R/adc_ingr.R
@@ -41,16 +41,35 @@ adc_ingr <- function(adc_test,
                      nut_ref, 
                      nut_ingr,
                      incl_ingr) {
+  # Checks----
+  ## Ensure inputs are numeric
+  stopifnot(is.numeric(adc_test), is.numeric(adc_ref),
+            is.numeric(nut_ref), is.numeric(nut_ingr),
+            is.numeric(incl_ingr))
   
-  # calculate ADC
+  
+  ## Ensure all inputs have the same length
+  input_lengths <- c(length(adc_test), length(adc_ref), length(nut_ref), length(nut_ingr), length(incl_ingr))
+  if (length(unique(input_lengths)) != 1) {
+    stop("All input vectors must have the same length.")
+  }
+  
+  
+  ## Warn if inputs are < 0
+  if (any(adc_test < 0 | adc_ref < 0 | nut_ref < 0 | nut_ingr < 0 | incl_ingr < 0)) {
+    warning("Some input values are negative. The result may not be meaningful.")
+  }
+  
+  
+  
+  # Calculations----
   adc_ingr <- ( adc_test + ( ((1-incl_ingr) * nut_ref) / (incl_ingr * nut_ingr) ) * (adc_test - adc_ref) )
 
   
   if(adc_ingr > 1) {
     warning("ADC > 1")
   }
-    
-  # return result
+  
+  
   return(adc_ingr)
-
 }

--- a/R/adc_ingr.R
+++ b/R/adc_ingr.R
@@ -47,7 +47,9 @@ adc_ingr <- function(adc_test,
   
   
   ## Ensure all inputs have the same length
-  input_lengths <- c(length(adc_test), length(adc_ref), length(nut_ref), length(nut_ingr), length(incl_ingr))
+  input_lengths <- c(length(adc_test), length(adc_ref), 
+                     length(nut_ref), length(nut_ingr), 
+                     length(incl_ingr))
   if (length(unique(input_lengths)) != 1) {
     stop("All input vectors must have the same length.")
   }

--- a/R/adc_nut.R
+++ b/R/adc_nut.R
@@ -3,17 +3,17 @@
 #' Function to calculate the Apparent Digestibility Coefficient of a nutrient
 #' in the dry matter fraction of a compound diet.
 #' 
-#' @param es_diet numeric; value resembling the inclusion rate of external
+#' @param std_diet numeric; value resembling the inclusion rate of
 #' standard in the experimental diet given to the livestock.
-#' @param es_feces numeric; value resembling the inclusion rate of external
+#' @param std_feces numeric; value resembling the inclusion rate of
 #' standard in the feces recovered during the digestibility trial.
 #' @param nut_diet numeric; value representing the inclusion rate of the 
 #' target nutrient in the diet. 
 #' @param nut_feces numeric; value representing the inclusion rate of the 
 #' target nutrient in the feces. 
 #' 
-#' @return returns a single numeric value which is the relative ADC for a
-#' single nutrient in the diet. If the value is not within the interval [0,1],
+#' @return returns a single numeric value in the interval [0, 1] which is the relative ADC for a
+#' single nutrient in the diet. If the value is not within the interval,
 #' an additional warning is returned.
 #' 
 #' 
@@ -25,30 +25,30 @@
 #' 
 #' 
 #' @export
-adc_nut <- function(es_diet, 
-                    es_feces, 
+adc_nut <- function(std_diet, 
+                    std_feces, 
                     nut_diet, 
                     nut_feces) {
   
   # Checks----
   ## Ensure inputs are numeric
-  stopifnot(is.numeric(es_diet), is.numeric(es_feces), 
+  stopifnot(is.numeric(std_diet), is.numeric(std_feces), 
             is.numeric(nut_diet), is.numeric(nut_feces))
   
   
   ## Ensure inputs have the same length
-  if (length(es_diet) != length(es_feces)) {
-    stop("Error: 'ibw' and 'fbw' must be of the same length.")
+  if (length(std_diet) != length(std_feces)) {
+    stop("All input vectors must have the same length.")
   }
   
   
   ## Check whether inputs are > 0
-  if (any(es_diet < 0 | es_feces < 0)) {
+  if (any(std_diet < 0 | std_feces < 0)) {
     warning("Some input values are negative. The result may not be meaningful.")
   }
 
   
   # Calculations----
-  adc_nut <- (1 - (es_diet / es_feces) * (nut_feces / nut_diet))
+  adc_nut <- (1 - (std_diet / std_feces) * (nut_feces / nut_diet))
   return(adc_nut)
 }

--- a/R/adc_nut.R
+++ b/R/adc_nut.R
@@ -29,8 +29,26 @@ adc_nut <- function(es_diet,
                     es_feces, 
                     nut_diet, 
                     nut_feces) {
+  
+  # Checks----
+  ## Ensure inputs are numeric
+  stopifnot(is.numeric(es_diet), is.numeric(es_feces), 
+            is.numeric(nut_diet), is.numeric(nut_feces))
+  
+  
+  ## Ensure inputs have the same length
+  if (length(es_diet) != length(es_feces)) {
+    stop("Error: 'ibw' and 'fbw' must be of the same length.")
+  }
+  
+  
+  ## Check whether inputs are > 0
+  if (any(es_diet < 0 | es_feces < 0)) {
+    warning("Some input values are negative. The result may not be meaningful.")
+  }
 
+  
+  # Calculations----
   adc_nut <- (1 - (es_diet / es_feces) * (nut_feces / nut_diet))
-
   return(adc_nut)
 }

--- a/R/adc_nut.R
+++ b/R/adc_nut.R
@@ -51,5 +51,10 @@ adc_nut <- function(std_diet,
   
   # Calculations----
   adc_nut <- (1 - (std_diet / std_feces) * (nut_feces / nut_diet))
+  
+  if(adc_nut > 1) {
+    warning("ADC > 1")
+  }
+  
   return(adc_nut)
 }

--- a/R/adc_nut.R
+++ b/R/adc_nut.R
@@ -37,13 +37,14 @@ adc_nut <- function(std_diet,
   
   
   ## Ensure inputs have the same length
-  if (length(std_diet) != length(std_feces)) {
+  input_lengths <- c(length(std_diet), length(std_feces), length(nut_diet), length(nut_feces))
+  if (length(unique(input_lengths)) != 1) {
     stop("All input vectors must have the same length.")
   }
   
   
   ## Check whether inputs are > 0
-  if (any(std_diet < 0 | std_feces < 0)) {
+  if (any(std_diet < 0 | std_feces < 0 | nut_diet < 0 | nut_feces < 0)) {
     warning("Some input values are negative. The result may not be meaningful.")
   }
 

--- a/R/retention.R
+++ b/R/retention.R
@@ -18,6 +18,19 @@ retention <- function(m_start,
                nut_start,
                m_end,
                nut_end) {
+  # Check for numeric and non-missing
+  if (any(is.na(c(m_start, m_end, nut_start, nut_end)))) 
+    stop("Inputs must not be NA")
+  
+  if (!all(sapply(list(m_start, m_end, nut_start, nut_end), is.numeric))) 
+    stop("All inputs must be numeric")
+
+  
+  # Warn if any value is <= 0
+  if (m_start <= 0) warning("m_start is zero or negative; result may not be meaningful")
+  if (m_end <= 0) warning("m_end is zero or negative; result may not be meaningful")
+  if (nut_start <= 0) warning("nut_start is zero or negative; result may not be meaningful")
+  if (nut_end <= 0) warning("nut_end is zero or negative; result may not be meaningful")
   
   retention <- m_end * nut_end - m_start * nut_start
   

--- a/tests/testthat/test-adc_dm.R
+++ b/tests/testthat/test-adc_dm.R
@@ -1,5 +1,6 @@
 test_that("Apparent Digestibility calculation of Dry Matter works", {
-  expect_equal(adc_dm(es_diet = 0.01,
-                      es_feces = 0.05), 
+  expect_equal(adc_dm(dm_diet = 1,
+                      std_diet = 0.01,
+                      std_feces = 0.05), 
                0.8)
 })

--- a/tests/testthat/test-adc_dm.R
+++ b/tests/testthat/test-adc_dm.R
@@ -11,9 +11,9 @@ test_that("adc_dm() throws error when inputs have different lengths", {
 })
 
 test_that("adc_dm() throws warning when input is < 0", {
-  expect_warning(adc_dm(dm_diet = -1, std_diet = 0.01, std_feces = 0.05))
-  expect_warning(adc_dm(dm_diet = 1, std_diet = -0.01, std_feces = 0.05))
-  expect_warning(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = -0.05))
+  expect_warning(expect_warning(adc_dm(dm_diet = -1, std_diet = 0.01, std_feces = 0.05)))
+  expect_warning(expect_warning(adc_dm(dm_diet = 1, std_diet = -0.01, std_feces = 0.05)))
+  expect_warning(expect_warning(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = -0.05)))
 })
 
 test_that("adc_dm() calculates ADC correctly", {

--- a/tests/testthat/test-adc_dm.R
+++ b/tests/testthat/test-adc_dm.R
@@ -16,6 +16,6 @@ test_that("adc_dm() throws warning when input is < 0", {
   expect_warning(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = -0.05))
 })
 
-test_that("adc_dm() calculates ADC of Dry Matter correctly", {
+test_that("adc_dm() calculates ADC correctly", {
   expect_equal(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = 0.05), 0.8)
 })

--- a/tests/testthat/test-adc_dm.R
+++ b/tests/testthat/test-adc_dm.R
@@ -1,6 +1,21 @@
-test_that("Apparent Digestibility calculation of Dry Matter works", {
-  expect_equal(adc_dm(dm_diet = 1,
-                      std_diet = 0.01,
-                      std_feces = 0.05), 
-               0.8)
+test_that("adc_dm() throws error when input is not numeric", {
+  expect_error(adc_dm(dm_diet = "a", std_diet = 0.01, std_feces = 0.05))
+  expect_error(adc_dm(dm_diet = 1, std_diet = "b", std_feces = 0.05))
+  expect_error(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = "c"))
+})
+
+test_that("adc_dm() throws error when inputs have different lengths", {
+  expect_error(adc_dm(dm_diet = c(1,1), std_diet = 0.01, std_feces = 0.05))
+  expect_error(adc_dm(dm_diet = 1, std_diet = c(0.01, 0.01), std_feces = 0.05))
+  expect_error(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = c(0.05, 0.05)))
+})
+
+test_that("adc_dm() throws warning when input is < 0", {
+  expect_warning(adc_dm(dm_diet = -1, std_diet = 0.01, std_feces = 0.05))
+  expect_warning(adc_dm(dm_diet = 1, std_diet = -0.01, std_feces = 0.05))
+  expect_warning(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = -0.05))
+})
+
+test_that("adc_dm() calculates ADC of Dry Matter correctly", {
+  expect_equal(adc_dm(dm_diet = 1, std_diet = 0.01, std_feces = 0.05), 0.8)
 })

--- a/tests/testthat/test-adc_ing.R
+++ b/tests/testthat/test-adc_ing.R
@@ -1,8 +1,0 @@
-test_that("multiplication works", {
-  expect_equal(adc_ingr(adc_test = 0.902,
-                        adc_ref = 0.923,
-                        nut_ref = 0.465,
-                        nut_ingr = 0.945,
-                        incl_ingr = 0.3), 
-               0.8778889) # From Bureau and Hua, 2001
-})

--- a/tests/testthat/test-adc_ingr.R
+++ b/tests/testthat/test-adc_ingr.R
@@ -1,0 +1,29 @@
+# Example data from Bureau and Hua, 2001
+
+test_that("adc_ingr() throws error when input is not numeric", {
+  expect_error(adc_ingr(adc_test = "a", adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = "b", nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = "c", nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = "d", incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = "e"))
+})
+
+test_that("adc_ingr() throws error when inputs are of different length", {
+  expect_error(adc_ingr(adc_test = c(0.902, 0.902), adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = c(0.923, 0.923), nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = c(0.465, 0.465), nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = c(0.945, 0.945), incl_ingr = 0.3))
+  expect_error(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = c(0.3, 0.3)))
+})
+
+test_that("adc_ingr() throws warning when input is < 0", {
+  expect_warning(adc_ingr(adc_test = -0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_warning(expect_warning(adc_ingr(adc_test = 0.902, adc_ref = -0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3))) # throws additional warning
+  expect_warning(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = -0.465, nut_ingr = 0.945, incl_ingr = 0.3))
+  expect_warning(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = -0.945, incl_ingr = 0.3))
+  expect_warning(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = -0.3))
+})
+
+test_that("adc_ignr() calculates ADC correctly", {
+  expect_equal(adc_ingr(adc_test = 0.902, adc_ref = 0.923, nut_ref = 0.465, nut_ingr = 0.945, incl_ingr = 0.3), 0.8778889) 
+})

--- a/tests/testthat/test-adc_nut.R
+++ b/tests/testthat/test-adc_nut.R
@@ -1,7 +1,24 @@
-test_that("Apparent Digestibility Coefficient calculation for a nutrient works", {
-  expect_equal(adc_nut(es_diet = 0.01, 
-                       es_feces = 0.05, 
-                       nut_diet = 0.8, 
-                       nut_feces = 0.1), 
-               0.975)
+test_that("adc_nut() throws error when input is not numeric", {
+  expect_error(adc_nut(std_diet = "a", std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = "b", nut_diet = 0.8, nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = "c", nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = "d"))
+})
+
+test_that("adc_nut() throws error when inputs are of different length", {
+  expect_error(adc_nut(std_diet = c(0.01, 0.01), std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = c(0.05, 0.05), nut_diet = 0.8, nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = c(0.8, 0.8), nut_feces = 0.1))
+  expect_error(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = c(0.1, 0.1)))
+})
+
+test_that("adc_nut() throws warning when input is < 0", {
+  expect_warning(adc_nut(std_diet = -0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1))
+  expect_warning(adc_nut(std_diet = 0.01, std_feces = -0.05, nut_diet = 0.8, nut_feces = 0.1))
+  expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = -0.8, nut_feces = 0.1))
+  expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = -0.1))
+})
+
+test_that("adc_nut() calculates ADC correctly", {
+  expect_equal(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1), 0.975)
 })

--- a/tests/testthat/test-adc_nut.R
+++ b/tests/testthat/test-adc_nut.R
@@ -13,10 +13,10 @@ test_that("adc_nut() throws error when inputs are of different length", {
 })
 
 test_that("adc_nut() throws warning when input is < 0", {
-  expect_warning(adc_nut(std_diet = -0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1))
-  expect_warning(adc_nut(std_diet = 0.01, std_feces = -0.05, nut_diet = 0.8, nut_feces = 0.1))
-  expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = -0.8, nut_feces = 0.1))
-  expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = -0.1))
+  expect_warning(expect_warning(adc_nut(std_diet = -0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = 0.1)))
+  expect_warning(expect_warning(adc_nut(std_diet = 0.01, std_feces = -0.05, nut_diet = 0.8, nut_feces = 0.1)))
+  expect_warning(expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = -0.8, nut_feces = 0.1)))
+  expect_warning(expect_warning(adc_nut(std_diet = 0.01, std_feces = 0.05, nut_diet = 0.8, nut_feces = -0.1)))
 })
 
 test_that("adc_nut() calculates ADC correctly", {

--- a/tests/testthat/test-retention.R
+++ b/tests/testthat/test-retention.R
@@ -1,7 +1,21 @@
-test_that("Nutrient retention calculation works", {
-  expect_equal(retention(m_start = 1, 
-                         nut_start = 0.1, 
-                         m_end = 2, 
-                         nut_end = 0.2), 
-               0.3)
+test_that( "nutrient retention", {
+  
+  expect_warning(retention(m_start=-1, m_end= 2, nut_start=3,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= -2, nut_start=3,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= 2, nut_start=-3,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= 2, nut_start=3,nut_end=-4))
+  expect_warning(retention(m_start=0, m_end= 2, nut_start=3,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= 0, nut_start=3,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= 2, nut_start=0,nut_end=4))
+  expect_warning(retention(m_start=1, m_end= 2, nut_start=3,nut_end=0))
+  expect_error(retention(m_start= 'test', m_end= 2, nut_start=3,nut_end=4))
+  expect_error(retention(m_start=1, m_end= 'test', nut_start=3,nut_end=4))
+  expect_error(retention(m_start=1, m_end= 2, nut_start= 'test',nut_end=4))
+  expect_error(retention(m_start=1, m_end= 2, nut_start=3,nut_end= 'test'))
+  expect_error(retention(m_start=NA, m_end= 2, nut_start=3,nut_end=4))
+  expect_error(retention(m_start=1, m_end= NA, nut_start=3,nut_end=4))
+  expect_error(retention(m_start=1, m_end= 2, nut_start=NA,nut_end=4))
+  expect_error(retention(m_start=1, m_end= 2, nut_start=3,nut_end=NA))
+  expect_error(retention(m_start> m_end, nut_start=3,nut_end=4))
+  expect_error(retention(m_start=1, m_end= 2, nut_start<nut_end))
 })


### PR DESCRIPTION
Following changes have been made:

- addition of checks to ensure numeric inputs, inputs of equal length, and inputs >0
- renaming of `es_` arguments to `std_` arguments (_es_ stood for _external standard_, which ignores the potential use of potential internal standards such as acid insoluble ash)
- removing the note from `adc_ingr()` and moving the text into the description, as suggested by the documentation of the `roxygen2` package.